### PR TITLE
Replace wiki links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,11 @@
 import React from 'react';
-import { HashRouter as Router, Switch, Route, Link } from 'react-router-dom';
+import {
+  HashRouter as Router,
+  Switch,
+  Route,
+  Link,
+  withRouter,
+} from 'react-router-dom';
 
 // This site has 3 pages, all of which are rendered
 // dynamically in the browser (not server rendered).
@@ -43,7 +49,7 @@ export default function App() {
             <About />
           </Route>
         </Switch> */}
-        <RabbitHole />
+        <RabbitHolePage />
       </div>
     </Router>
   );
@@ -68,48 +74,86 @@ function About() {
   );
 }
 
-class RabbitHole extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      wikiData: {},   
+const RabbitHolePage = withRouter(
+  class RabbitHole extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        wikiData: {},
+      };
+    }
+
+    componentDidMount() {
+      fetch(
+        `https://en.wikipedia.org/api/rest_v1/page/random/mobile-sections`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+        .then((resp) => resp.json())
+        .then((resp) => {
+          console.log('resp', resp);
+
+          this.setState({ wikiData: resp });
+        });
+    }
+
+    /**
+     * Replace links to `/wiki/` page in in API response with
+     * a URl search string instead. This allows us to update the
+     * URL value without navigating away from the page.
+     */
+    replaceLinks(text) {
+      if (!text) {
+        return text;
+      }
+
+      // Add onto the existing URL search string
+      const searchParams = new URLSearchParams(this.props.location.search);
+      const wikiValue = searchParams.get('wiki');
+
+      return text.replace(
+        /\/wiki\//g,
+        // Each page in the rabbit hole journey added to the links
+        // on the page, separated by "|"s.
+        // For example:
+        //  1. /wiki/Pet_door  ->  /#/?wiki=Pet_door
+        //  2. /wiki/Dog       ->  /#/?wiki=Pet_door|Dog
+        //  3. /wiki/Mammal    ->  /#/?wiki=Pet_door|Dog|Mammal
+        `/#/?wiki=${wikiValue ? `${wikiValue}|` : ''}`
+      );
+    }
+
+    render() {
+      return (
+        <div>
+          {this.state.wikiData.lead &&
+            this.state.wikiData.lead.sections &&
+            this.state.wikiData.lead.sections.map((section) => (
+              <div
+                key={section.id}
+                dangerouslySetInnerHTML={{
+                  __html: this.replaceLinks(section.text),
+                }}
+              />
+            ))}
+
+          {this.state.wikiData.remaining &&
+            this.state.wikiData.remaining.sections &&
+            this.state.wikiData.remaining.sections.map((section) => (
+              <div key={section.id}>
+                <h2>{section.line}</h2>
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: this.replaceLinks(section.text),
+                  }}
+                />
+              </div>
+            ))}
+        </div>
+      );
     }
   }
-
-  componentDidMount() {
-    fetch(`https://en.wikipedia.org/api/rest_v1/page/random/mobile-sections`, {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
-      .then((resp) => resp.json())
-      .then((resp) => {
-        console.log('resp', resp);
-
-        this.setState({ wikiData: resp });
-      });
-  }
-
-
-  render() {
-    return <div>
-      {this.state.wikiData.lead &&
-      this.state.wikiData.lead.sections &&
-      this.state.wikiData.lead.sections.map((section) => (
-        <div
-          key={section.id}
-          dangerouslySetInnerHTML={{ __html: section.text }}
-        />
-      ))}
-      
-      {this.state.wikiData.remaining &&
-      this.state.wikiData.remaining.sections &&
-      this.state.wikiData.remaining.sections.map((section) => (
-        <div key={section.id}>
-          <h2>{section.line}</h2>
-          <div dangerouslySetInnerHTML={{ __html: section.text }}/>
-        </div>
-      ))}
-  </div>
-  }
-}
+);

--- a/src/App.js
+++ b/src/App.js
@@ -101,6 +101,23 @@ const RabbitHolePage = withRouter(
     }
 
     /**
+     * TODO Check for updates to the component so that we can detect
+     * when there are changes to the URL. In our case, we want
+     * to detect changes to the location search params and render
+     * the new Wikipedia component based on the last clicked link.
+     */
+    componentDidUpdate(prevProps) {
+      if (this.props.location.search !== prevProps.location.search) {
+        const searchParams = new URLSearchParams(this.props.location.search);
+        const wikiValue = searchParams.get('wiki');
+
+        if (wikiValue) {
+          console.log('TODO:', wikiValue);
+        }
+      }
+    }
+
+    /**
      * Replace links to `/wiki/` page in in API response with
      * a URl search string instead. This allows us to update the
      * URL value without navigating away from the page.


### PR DESCRIPTION
Replace all Wikipedia links in the API response with a [location search parameter](https://www.w3schools.com/jsref/prop_loc_search.asp). This prevents users from navigating away from our app, so that we can control what happens when a user clicks a link. Left in a TODO to actually update the content to reflect the navigation change.

Addresses part 2 of https://github.com/bestprogrammingclub/rabbithole/issues/1