### PR TITLE
Fix prod links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -196,9 +196,9 @@ const RabbitHolePage = withRouter(
 
       return (
         <div>
-          <a href="/#/" onClick={() => this.startNewRabbithole()}>
+          <Link to="/#/" onClick={() => this.startNewRabbithole()}>
             START OVER
-          </a>
+          </Link>
 
           <ul>
             {rabbitHolePath.map((pageTitle, index) => (


### PR DESCRIPTION
Fix "Start Over" link in prod site (https://bestprogrammingclub.github.io/rabbithole) taking you to a 404 page.

When using a plain `a` tag, we don't take React Router's integration with React to our advantage. By using the [Link](https://reactrouter.com/web/api/Link) component provided by React Router, we're able to link to the index route (`/`) relative to our application, not relative to the website.

Manual testing locally:
1. Run the application with `npm start` and wait for page load
2. Click START OVER link at top. Page should reload and URL should update as expected