### PR TITLE
Fix custom URL home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ### Deploying
 
-Merging to the `main` branch will automatically deploy the app to [bestprogrammingclub.github.io/rabbithole](https://bestprogrammingclub.github.io/rabbithole/). You can monitor deploys in the [Actions tab](https://github.com/bestprogrammingclub/rabbithole/actions).
+Merging to the `main` branch will automatically deploy the app to [bestprogrammingclub.github.io/rabbithole](https://bestprogrammingclub.github.io/rabbithole/) / <rabbithole.bestprogramming.club>. You can monitor deploys in the [Actions tab](https://github.com/bestprogrammingclub/rabbithole/actions).
 
 To manually deploy the app:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ### Deploying
 
-Merging to the `main` branch will automatically deploy the app to [bestprogrammingclub.github.io/rabbithole](https://bestprogrammingclub.github.io/rabbithole/) / <rabbithole.bestprogramming.club>. You can monitor deploys in the [Actions tab](https://github.com/bestprogrammingclub/rabbithole/actions).
+Merging to the `main` branch will automatically deploy the app to [bestprogrammingclub.github.io/rabbithole](https://bestprogrammingclub.github.io/rabbithole/) / [rabbithole.bestprogramming.club](rabbithole.bestprogramming.club). You can monitor deploys in the [Actions tab](https://github.com/bestprogrammingclub/rabbithole/actions).
 
 To manually deploy the app:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rabbithole",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://bestprogrammingclub.github.io/rabbithole/",
+  "homepage": ".",
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",


### PR DESCRIPTION
Fixes files not loading from the custom GitHub pages URL (<http://rabbithole.bestprogramming.club>.)

Contexct: This was due to `rabbithole.bestprogramming.club` expecting Javascript files to be served from the root directory, while the GitHub page expected JS files to be served from `/rabbithole`. Using a relative path seems to fix this issue.

Manual testing: Run the app with `npm start`. App should load and navigation should work as expected.

Reference:
- [CRA docs on Building for Relative Paths](https://create-react-app.dev/docs/deployment/#building-for-relative-paths)
- [CRA docs on Serving the Same Build from Different Paths](https://create-react-app.dev/docs/deployment/#serving-the-same-build-from-different-paths)
